### PR TITLE
Fix errors in DK:GEO_GS

### DIFF
--- a/resources/DK
+++ b/resources/DK
@@ -173,12 +173,12 @@ expect      687178.31448147167  390074.81929540867
             units=m no_defs
 
 # Generalstabens lcc Jutland and Zealand (lon_0 = 2 12 nt, W positive)
-<_GS_FORMAL>  proj=lcc lat_ts=56 lat_0=55 lon_0=2.2
-             x_0=0    y_0=0   ellps=GS
+<_GS_FORMAL>  proj=lcc lat_1=56 lat_0=55 lon_0=2.2
+             x_0=0    y_0=0   ellps=andrae
 
 # Generalstabens konform-koniske for Bornholm (lon_0 = -2 21 nt, W positive)
 <_GSB_FORMAL> proj=lcc lat_1=56 lat_0=55 lon_0=-2.35 # lat_ts=56
-             x_0=18831.460 y_0=5614.621 ellps=GS
+             x_0=18831.460 y_0=5614.621 ellps=andrae
 
 # Koebenhavns Kommune
 # <_KK_FORMAL>  proj=localcrd ellps=danish units=m no_defs
@@ -475,9 +475,11 @@ expect      112779.7960  275908.0748   # Authoritative value, obtained from KMST
     step   init=DK:UTM32_ED50_L
     step   init=DK_general.pol:GS
 #------------------------------------------------------------------------------------------------------
-<GEO_GS> proj=pipeline  ellps=GRS80
+<GEO_GS> proj=pipeline
+    step   proj=push v_3
     step   init=DK:GS
-    step   init=DK:GS_FORMAL inv
+    step   init=DK:_GS_FORMAL inv
+    step   proj=pop v_3
 #------------------------------------------------------------------------------------------------------
 <gie>
 operation   init=DK:GS
@@ -510,9 +512,11 @@ expect      10  57
     step   init=DK:UTM33_ED50_B
     step   init=DK_bornholm.pol:GSB
 #------------------------------------------------------------------------------------------------------
-<GEO_GSB> proj=pipeline  ellps=GRS80       #
+<GEO_GSB> proj=pipeline
+    step   proj=push v_3
     step   init=DK:GSB
     step   init=DK:_GSB_FORMAL inv
+    step   proj=pop v_3
 #------------------------------------------------------------------------------------------------------
 <gie>
 operation   init=DK:GSB

--- a/tests/geo_gs.gie
+++ b/tests/geo_gs.gie
@@ -1,0 +1,22 @@
+<gie>
+
+---------------------------------------------
+From GEO_GS to ETRS89
+---------------------------------------------
+operation   +init=DK:GEO_GS
+tolerance   1 cm
+direction   inverse
+
+accept      1.930208333     55.56633333     0
+expect      10.645928687    55.566277007    0
+roundtrip   10
+
+accept      1.932541667     55.42816667     0
+expect      10.643603061    55.428131578    0
+roundtrip   10
+
+accept      1.879708333     55.34883333     0
+expect      10.696431567    55.348811106    0
+roundtrip   10
+
+</gie>


### PR DESCRIPTION
A few errors were detected in the geodetic coordinate
version of system generalstaben:

- Using GRS80 ellipsoid instead of andrae
- Setting +lat_ts instead of +lat_1
- The height of the input coordinate was changed during
  the transformation. This shouldn't happen for in a 2D
  system. With the new push/pop operations this can now
  be taken into account.

 A new gie file with a few test coordinates has been
 added to tests/. Transformations in the gie file
 reproduce transformations from KMSTrans2 within
 ~60 micrometers.